### PR TITLE
Clarify location of SENTRY_AUTH_TOKEN in Sentry UI

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -26,7 +26,7 @@ Once you see the onboarding page which has the DSN, copy that somewhere (this
 becomes `SENTRY_DSN`). Then click
 [this](https://sentry.io/orgredirect/settings/:orgslug/developer-settings/new-internal/)
 to create an internal integration. Give it a name and add the scope for
-`Releases:Admin`. Press Save, find the auth token at the bottom of the page, and
+`Releases:Admin`. Press Save, find the auth token at the bottom of the page under "Tokens", and
 copy that to secure location (this becomes `SENTRY_AUTH_TOKEN`). Then vist the
 organization settings page and copy that organization slug (`SENTRY_ORG_SLUG`).
 


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
Prevent ambiguity between the `SENTRY_AUTH_TOKEN` at the bottom of the page and the `Client Secret` located at the very bottom of the page which looks like a token without being the correct one.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
